### PR TITLE
Add backend bill analysis endpoint and integrate upload flow

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,25 +20,32 @@ import Footer from './components/Footer';
 function App() {
   const [uploadedFile, setUploadedFile] = useState<File | null>(null);
   const [uploadStatus, setUploadStatus] = useState<'idle' | 'uploading' | 'success' | 'error'>('idle');
-  const [analysisResult, setAnalysisResult] = useState<{
-    overchargeAmount: number;
-    errorCount: number;
-    emailSent: boolean;
-  } | null>(null);
+  const [analysisResult, setAnalysisResult] = useState<string | null>(null);
 
-  const handleFileUpload = (file: File) => {
+  const handleFileUpload = async (file: File) => {
     setUploadedFile(file);
     setUploadStatus('uploading');
-    
-    // Simulate API call
-    setTimeout(() => {
-      setUploadStatus('success');
-      setAnalysisResult({
-        overchargeAmount: 1247.83,
-        errorCount: 3,
-        emailSent: true
+
+    const formData = new FormData();
+    formData.append('file', file);
+
+    try {
+      const response = await fetch('http://localhost:8000/analyze-bill', {
+        method: 'POST',
+        body: formData
       });
-    }, 3000);
+
+      if (!response.ok) {
+        throw new Error('Request failed');
+      }
+
+      const data = await response.json();
+      setAnalysisResult(data.analysis);
+      setUploadStatus('success');
+    } catch (error) {
+      console.error(error);
+      setUploadStatus('error');
+    }
   };
 
   const resetUpload = () => {

--- a/frontend/src/components/UploadSection.tsx
+++ b/frontend/src/components/UploadSection.tsx
@@ -4,11 +4,7 @@ import { Upload, FileCheck, DollarSign, Mail, AlertCircle, CheckCircle, RefreshC
 interface UploadSectionProps {
   uploadedFile: File | null;
   uploadStatus: 'idle' | 'uploading' | 'success' | 'error';
-  analysisResult: {
-    overchargeAmount: number;
-    errorCount: number;
-    emailSent: boolean;
-  } | null;
+  analysisResult: string | null;
   onFileUpload: (file: File) => void;
   onReset: () => void;
 }
@@ -123,38 +119,17 @@ const UploadSection: React.FC<UploadSectionProps> = ({
           <h3 className="text-2xl font-bold text-center text-gray-800 mb-6">
             Analysis Complete!
           </h3>
-          
+
           <div className="bg-green-50 p-6 rounded-lg mb-6">
             <div className="flex justify-between items-center mb-4">
               <span className="text-gray-700">Uploaded File:</span>
               <span className="font-medium">{uploadedFile?.name}</span>
             </div>
-            <div className="flex justify-between items-center mb-4">
-              <span className="text-gray-700">Errors Found:</span>
-              <span className="font-medium">{analysisResult.errorCount}</span>
-            </div>
-            <div className="flex justify-between items-center mb-4">
-              <span className="text-gray-700">Potential Savings:</span>
-              <span className="text-2xl font-bold text-green-600">${analysisResult.overchargeAmount.toFixed(2)}</span>
-            </div>
-            <div className="flex justify-between items-center">
-              <span className="text-gray-700">Dispute Email:</span>
-              <span className="font-medium flex items-center text-green-600">
-                <CheckCircle className="h-4 w-4 mr-1" />
-                Sent
-              </span>
-            </div>
+            <pre className="whitespace-pre-wrap text-sm text-gray-700">
+              {analysisResult}
+            </pre>
           </div>
-          
-          <div className="bg-blue-50 p-6 rounded-lg mb-6">
-            <h4 className="font-semibold text-blue-800 mb-3">What happens next?</h4>
-            <ol className="list-decimal list-inside space-y-2 text-gray-700">
-              <li>The hospital will review your dispute (typically 5-10 business days)</li>
-              <li>You'll receive an email notification when they respond</li>
-              <li>If approved, you'll receive a refund or adjusted bill</li>
-            </ol>
-          </div>
-          
+
           <button
             onClick={onReset}
             className="w-full px-6 py-3 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition-colors flex items-center justify-center"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+python-dotenv
+openai
+pdf2image
+pillow

--- a/server.py
+++ b/server.py
@@ -1,0 +1,39 @@
+from fastapi import FastAPI, UploadFile, File, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+import tempfile
+import shutil
+import os
+from samplepipeline import (
+    process_bill_image,
+    identify_clerical_errors,
+    identify_clerical_errors_pdf,
+)
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+@app.post("/analyze-bill")
+def analyze_bill(file: UploadFile = File(...)):
+    try:
+        suffix = os.path.splitext(file.filename)[1]
+        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+            shutil.copyfileobj(file.file, tmp)
+            temp_path = tmp.name
+        ext = os.path.splitext(temp_path)[1].lower()
+        if ext == ".pdf":
+            images = process_bill_image(temp_path)
+            result = identify_clerical_errors_pdf(images)
+        else:
+            image = process_bill_image(temp_path)
+            result = identify_clerical_errors(image)
+        os.remove(temp_path)
+        return {"analysis": result}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
## Summary
- add FastAPI server with /analyze-bill endpoint calling samplepipeline
- create requirements list for backend
- connect frontend upload flow to backend and display analysis text
- simplify UploadSection success output

## Testing
- `python -m py_compile samplepipeline.py server.py`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6733e780832885705f0bd51fe3d5