### PR TITLE
Improve bill analysis display

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-markdown": "^9.0.3",
+    "remark-gfm": "^3.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/frontend/src/components/UploadSection.tsx
+++ b/frontend/src/components/UploadSection.tsx
@@ -1,5 +1,7 @@
 import React, { useRef, useState } from 'react';
 import { Upload, AlertCircle, RefreshCw } from 'lucide-react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 
 interface UploadSectionProps {
   uploadStatus: 'idle' | 'uploading' | 'success' | 'error';
@@ -111,9 +113,9 @@ const UploadSection: React.FC<UploadSectionProps> = ({
 
       {uploadStatus === 'success' && analysisResult && (
         <div className="border rounded-lg p-8 bg-white shadow">
-          <pre className="whitespace-pre-wrap text-sm text-gray-700 mb-6">
-            {analysisResult}
-          </pre>
+          <div className="text-sm text-gray-700 mb-6 space-y-2">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{analysisResult}</ReactMarkdown>
+          </div>
           <button
             onClick={onReset}
             className="w-full px-6 py-3 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition-colors flex items-center justify-center"


### PR DESCRIPTION
## Summary
- display AI bill analysis in Markdown format
- add react-markdown and remark-gfm dependencies

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f7ab134cc8328a4b45327098482d3