### PR TITLE
Enable HEIC uploads

### DIFF
--- a/frontend/src/components/UploadSection.tsx
+++ b/frontend/src/components/UploadSection.tsx
@@ -85,11 +85,11 @@ const UploadSection: React.FC<UploadSectionProps> = ({
             ref={fileInputRef}
             type="file"
             className="hidden"
-            accept=".pdf,.jpg,.jpeg,.png"
+            accept=".pdf,.jpg,.jpeg,.png,.heic"
             onChange={handleChange}
           />
           <p className="mt-4 text-sm text-gray-500">
-            Supported formats: PDF, JPG, PNG
+            Supported formats: PDF, JPG, PNG, HEIC
           </p>
         </div>
       )}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-dotenv
 openai
 pdf2image
 pillow
+pillow-heif


### PR DESCRIPTION
## Summary
- support HEIC image conversion on the backend
- allow HEIC uploads from the frontend
- add pillow-heif dependency

## Testing
- `python -m py_compile server.py samplepipeline.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841deb3e1888328ab51b39a4851ddce