### PR TITLE
Update crawler dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# VeriCare
+
+## Prerequisites
+- Python 3.11+
+- Node.js 18+
+
+## Setup
+1. Install Python dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Install frontend dependencies:
+   ```bash
+   cd frontend
+   npm install
+   cd ..
+   ```
+
+## Running the Backend
+Start the FastAPI server:
+```bash
+uvicorn server:app --reload
+```
+
+## Running the Frontend
+From the `frontend` directory:
+```bash
+npm run dev
+```
+
+This will start the Vite development server.
+
+Make sure environment variables such as OpenAI API keys and Composio API keys are available so the crawler and AI features work correctly.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ openai
 pdf2image
 pillow
 pillow-heif
+langchain
+langchain-openai
+composio-langchain


### PR DESCRIPTION
## Summary
- add missing packages for crawler support in requirements
- document how to run the backend and frontend

## Testing
- `python -m py_compile server.py samplepipeline.py searchpipeline.py`
- `python server.py` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pip install python-dotenv` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841fc00ab908328b7ecb8d626d574b9