### PR TITLE
Fix missing python-multipart dep and fallback imports

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ openai
 pdf2image
 pillow
 pillow-heif
+python-multipart

--- a/samplepipeline.py
+++ b/samplepipeline.py
@@ -1,29 +1,58 @@
 import os
 import base64
-from dotenv import load_dotenv
-from openai import OpenAI
-from pdf2image import convert_from_path
-from PIL import Image
-from pillow_heif import register_heif_opener
 import tempfile
+
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover - optional dependency
+    def load_dotenv(*_args, **_kwargs):
+        """Fallback no-op if python-dotenv isn't installed."""
+        pass
+
+try:
+    from openai import OpenAI
+except ImportError as exc:  # pragma: no cover - optional dependency
+    OpenAI = None
+
+try:
+    from pdf2image import convert_from_path
+except ImportError:  # pragma: no cover - optional dependency
+    convert_from_path = None
+
+try:
+    from PIL import Image
+except ImportError:  # pragma: no cover - optional dependency
+    Image = None
+
+try:
+    from pillow_heif import register_heif_opener
+except ImportError:  # pragma: no cover - optional dependency
+    def register_heif_opener():
+        pass
 
 load_dotenv()
 register_heif_opener()
 
-client = OpenAI(
-    api_key=os.getenv("OPENROUTER_API_KEY"),
-    base_url="https://openrouter.ai/api/v1",
-    default_headers={
-        "HTTP-Referer": "https://github.com/",  # optional, update with your repo
-        "X-Title": "VeriCare"
-    },
-)
+if OpenAI is not None:
+    client = OpenAI(
+        api_key=os.getenv("OPENROUTER_API_KEY"),
+        base_url="https://openrouter.ai/api/v1",
+        default_headers={
+            "HTTP-Referer": "https://github.com/",  # optional, update with your repo
+            "X-Title": "VeriCare"
+        },
+    )
+else:  # pragma: no cover - optional dependency missing
+    client = None
 '''
 def process_bill_image(image_path: str):
     """
     Determines whether the input is a PDF or image and processes accordingly.
     Returns a single base64 string for image or a list of base64 strings for PDF.
     """
+    if Image is None:
+        raise ImportError("Pillow is required for image processing")
+
     ext = os.path.splitext(image_path)[1].lower()
     if ext == ".pdf":
         return process_bill_image_pdf(image_path)
@@ -43,6 +72,9 @@ def process_bill_image_pdf(pdf_path: str) -> list:
     """
     Converts each page of a PDF into an image and returns a list of base64-encoded strings.
     """
+    if convert_from_path is None:
+        raise ImportError("pdf2image is required for PDF processing")
+
     pages = convert_from_path(pdf_path, dpi=150)
     base64_images = []
 
@@ -62,12 +94,17 @@ def identify_clerical_errors(image_path: str) -> str:
     Sends a system prompt + user prompt (including a single base64 image)
     to gpt-4.1 using the v1 Chat Completions API.
     """
+    if OpenAI is None:
+        raise ImportError("openai package is required for this function")
+
     with open("prompt_clerical.txt", "r", encoding="utf-8") as f:
         prompt_clerical = f.read()
 
 
     ext = os.path.splitext(image_path)[1].lower()
     if ext in [".heic", ".heif"]:
+        if Image is None:
+            raise ImportError("Pillow is required for HEIC conversion")
         with Image.open(image_path) as img:
             with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
                 img.save(tmp.name, format="PNG")


### PR DESCRIPTION
## Summary
- handle optional dependencies in `samplepipeline`
- add `python-multipart` to requirements

## Testing
- `python -m py_compile server.py samplepipeline.py`
- `uvicorn server:app --port 8000 --reload` *(fails: python-multipart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a2e7b7dd88328bc34cfa36909a966