### PR TITLE
Update OpenRouter endpoint

### DIFF
--- a/samplepipeline.py
+++ b/samplepipeline.py
@@ -7,8 +7,12 @@ from pdf2image import convert_from_path
 load_dotenv()
 
 OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")
-OPENROUTER_BASE_URL = os.getenv("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
-MODEL_NAME = "gpt-4o-mini-search-preview"
+# Default to the GPT-4o search preview endpoint as documented by OpenRouter
+OPENROUTER_BASE_URL = os.getenv(
+    "OPENROUTER_BASE_URL",
+    "https://openrouter.ai/openai/gpt-4o-search-preview/api",
+)
+MODEL_NAME = "gpt-4o-search-preview"
 
 
 def _openrouter_chat_completion(messages):


### PR DESCRIPTION
## Summary
- align default OpenRouter base URL with `gpt-4o-search-preview` link
- use the `gpt-4o-search-preview` model for analysis

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile samplepipeline.py server.py`


------
https://chatgpt.com/codex/tasks/task_e_684a40cd93a883289e9339fd9a9d52a6