### PR TITLE
Fix Python 3.9 compatibility

### DIFF
--- a/samplepipeline.py
+++ b/samplepipeline.py
@@ -1,5 +1,6 @@
 import os
 import base64
+from typing import Union
 from openai import OpenAI
 from dotenv import load_dotenv
 from pdf2image import convert_from_path
@@ -33,7 +34,10 @@ def _openrouter_chat_completion(messages):
     return completion.choices[0].message.content
 
 
-def process_bill_image(image_path: str) -> str | list[str]:
+
+
+
+def process_bill_image(image_path: str) -> Union[str, list[str]]:
     """Process a single image or PDF and return base64 encoded string(s)."""
     ext = os.path.splitext(image_path)[1].lower()
     if ext == ".pdf":


### PR DESCRIPTION
## Summary
- import `Union` from typing
- replace `|` union syntax with `Union`

## Testing
- `python -m py_compile samplepipeline.py`
- `python -m py_compile server.py`
- `uvicorn server:app --port 8000 --reload` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_684a450f28648328aaca841f6d2c63a0