### PR TITLE
Fix integration by stubbing OpenAI and adding missing dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ python-dotenv
 openai
 pdf2image
 pillow
+
+python-multipart


### PR DESCRIPTION
## Summary
- add missing `python-multipart` dependency
- allow running backend without OpenAI by providing stub responses

## Testing
- `pip install -r requirements.txt`
- `npm install`
- `npm run build`
- `STUB_OPENAI=1 OPENAI_API_KEY=dummy uvicorn server:app --port 8000 &`
- `curl -F "file=@sample.png" http://localhost:8000/analyze-bill`

------
https://chatgpt.com/codex/tasks/task_e_684cde569b7883288539c698adfa7702