### PR TITLE
Fix pipeline return value for FastAPI endpoint

### DIFF
--- a/samplepipeline.py
+++ b/samplepipeline.py
@@ -70,7 +70,7 @@ def identify_clerical_errors(base64_image: str) -> str:
         input=input_information
     )
 
-    return response
+    return response.choices[0].message.content
 
 def identify_clerical_errors_pdf(base64_images: list) -> str:
     """


### PR DESCRIPTION
## Summary
- ensure `identify_clerical_errors` returns the text content rather than the raw OpenAI object

## Testing
- `python -m py_compile samplepipeline.py server.py`
- `npm run lint` in `frontend/`

------
https://chatgpt.com/codex/tasks/task_e_684ce1945f388328bc4f53926d36629f