### PR TITLE
Add OCR fallback for OpenAI failures

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ python-dotenv
 openai
 pdf2image
 pillow
+pytesseract
+requests


### PR DESCRIPTION
## Summary
- provide optional OPENAI_API_KEY setup and new OCR fallback via pytesseract
- ensure requests and pytesseract dependencies are installed

## Testing
- `python -m py_compile samplepipeline.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d823502f88328957d73259371e9c7