### PR TITLE
Fail early if OPENROUTER_API_KEY is missing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+OPENAI_API_KEY=your-openai-api-key
+OPENROUTER_API_KEY=your-openrouter-api-key

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# VeriCare
+
+This repository contains a simple pipeline (`samplepipeline.py`) and a FastAPI server for analyzing medical bills using AI models.
+
+## Setup
+
+1. Install Python dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Copy `.env.example` to `.env` and fill in your API keys:
+
+```bash
+cp .env.example .env
+```
+
+`OPENAI_API_KEY` is required for OCR with OpenAI and `OPENROUTER_API_KEY` is used for web-based analysis. Both variables must be defined for the pipeline to run correctly.
+
+## Running
+
+To test the pipeline directly:
+
+```bash
+python samplepipeline.py
+```
+
+Or start the server:
+
+```bash
+uvicorn server:app --reload
+```
+

--- a/samplepipeline.py
+++ b/samplepipeline.py
@@ -14,14 +14,12 @@ load_dotenv()
 # Setup API keys
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 openai_client = OpenAI(api_key=OPENAI_API_KEY) if OPENAI_API_KEY else None
-OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")  # Set in .env
 
-headers = {
-    "Authorization": f"Bearer {OPENROUTER_API_KEY}",
-    "HTTP-Referer": "https://yourdomain.com",  # Replace appropriately
-    "X-Title": "Medical Bill Analyzer",
-    "Content-Type": "application/json",
-}
+OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")  # Set in .env
+if not OPENROUTER_API_KEY:
+    raise EnvironmentError(
+        "OPENROUTER_API_KEY is missing. Set it in your environment or .env file."
+    )
 
 
 def process_bill_image(image_path: str):
@@ -87,6 +85,11 @@ def extract_text_from_image(base64_image: str) -> str:
 
 def analyze_with_web_search(bill_text: str) -> str:
     """Uses OpenRouter to search the web for additional context or errors."""
+    if not OPENROUTER_API_KEY:
+        raise EnvironmentError(
+            "OPENROUTER_API_KEY is not configured. Set it in your environment or .env file."
+        )
+
     with open("prompt_clerical.txt", "r", encoding="utf-8") as f:
         prompt_clerical = f.read()
 
@@ -97,6 +100,13 @@ def analyze_with_web_search(bill_text: str) -> str:
     payload = {
         "model": "openai/gpt-4o:online",  # Or "openai/gpt-4o-search-preview"
         "messages": [{"role": "user", "content": search_prompt}],
+    }
+
+    headers = {
+        "Authorization": f"Bearer {OPENROUTER_API_KEY}",
+        "HTTP-Referer": "https://yourdomain.com",  # Replace appropriately
+        "X-Title": "Medical Bill Analyzer",
+        "Content-Type": "application/json",
     }
 
     response = requests.post(


### PR DESCRIPTION
## Summary
- check for missing `OPENROUTER_API_KEY` at import time
- guard `analyze_with_web_search` from running without a key
- document environment variables
- add `.env.example`

## Testing
- `python -m py_compile samplepipeline.py server.py`


------
https://chatgpt.com/codex/tasks/task_e_684d862005608328b47b8b53c7c99d8d