### PR TITLE
Switch search to Perplexity Sonar

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ pip install -r requirements.txt
 cp .env.example .env
 ```
 
-`OPENAI_API_KEY` is required for OCR with OpenAI and `OPENROUTER_API_KEY` is used for web-based analysis. Both variables must be defined for the pipeline to run correctly.
+`OPENAI_API_KEY` is required for OCR with OpenAI and `OPENROUTER_API_KEY` is used for web-based analysis via Perplexity's Sonar Deep Research model on OpenRouter. Both variables must be defined for the pipeline to run correctly.
 
 ## Running
 

--- a/samplepipeline.py
+++ b/samplepipeline.py
@@ -94,11 +94,16 @@ def analyze_with_web_search(bill_text: str) -> str:
         prompt_clerical = f.read()
 
     search_prompt = (
-        f"{prompt_clerical}\n\nPlease analyze the following medical bill:\n{bill_text}"
+        f"{prompt_clerical}\n\n"
+        "You are connected to Perplexity's Sonar Deep Research engine. "
+        "Search the web thoroughly for each billing code and any known clerical errors, "
+        "typical pricing ranges, or duplicate charge issues. "
+        "Use this information to provide the most comprehensive analysis possible.\n"
+        f"Medical bill text:\n{bill_text}"
     )
 
     payload = {
-        "model": "openai/gpt-4o:online",  # Or "openai/gpt-4o-search-preview"
+        "model": "perplexity/sonar-deep-research",  # Web search model
         "messages": [{"role": "user", "content": search_prompt}],
     }
 


### PR DESCRIPTION
## Summary
- use Perplexity's Sonar Deep Research via OpenRouter for bill analysis
- refine the search prompt to gather extra context
- document the new search model in README

## Testing
- `python -m py_compile samplepipeline.py server.py`
- `OPENROUTER_API_KEY=dummy OPENAI_API_KEY=dummy python samplepipeline.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684d9027294883289f82668eb0ca0aaa